### PR TITLE
Fix sendgrid attachment sending error

### DIFF
--- a/opwen_email_server/services/sendgrid.py
+++ b/opwen_email_server/services/sendgrid.py
@@ -15,6 +15,7 @@ from sendgrid.helpers.mail import Personalization
 from opwen_email_server.constants.sendgrid import INBOX_URL
 from opwen_email_server.constants.sendgrid import MAILBOX_URL
 from opwen_email_server.utils.log import LogMixin
+from opwen_email_server.utils.serialization import to_base64
 
 
 class SendSendgridEmail(LogMixin):
@@ -99,14 +100,14 @@ class SendSendgridEmail(LogMixin):
     @classmethod
     def _create_attachment(cls, attachment: dict) -> Attachment:
         filename = attachment.get('filename', '')
-        content = attachment.get('content', '')
+        content = attachment.get('content', b'')
 
         mail_attachment = Attachment()
         mail_attachment.disposition = 'attachment'
         mail_attachment.filename = filename
         mail_attachment.content_id = filename
         mail_attachment.type = guess_type(filename)[0]
-        mail_attachment.content = content
+        mail_attachment.content = to_base64(content)
 
         return mail_attachment
 


### PR DESCRIPTION
Stacktrace:

```
  File "/app/opwen_email_server/actions.py", line 32, in __call__
    return self._action(*args, **kwargs)
  File "/app/opwen_email_server/actions.py", line 59, in _action
    success = self._send_email(email)
  File "/app/opwen_email_server/services/sendgrid.py", line 43, in __call__
    return self._send_email(email, email_id)
  File "/app/opwen_email_server/services/sendgrid.py", line 49, in _send_email
    status = self._client(request)
  File "/app/opwen_email_server/services/sendgrid.py", line 35, in send_email
    response = client.client.mail.send.post(request_body=email)
  File "/venv/lib/python3.6/site-packages/python_http_client/client.py", line 236, in http_request
    kwargs['request_body']).encode('utf-8')
  File "/usr/local/lib/python3.6/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.6/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.6/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'bytes' is not JSON serializable
```