### PR TITLE
Prevent non-lowercase client names

### DIFF
--- a/opwen_email_server/actions.py
+++ b/opwen_email_server/actions.py
@@ -22,6 +22,7 @@ from opwen_email_server.utils.serialization import from_base64
 from opwen_email_server.utils.serialization import from_jsonl_bytes
 from opwen_email_server.utils.serialization import to_base64
 from opwen_email_server.utils.serialization import to_jsonl_bytes
+from opwen_email_server.utils.string import is_lowercase
 
 Response = Union[dict, Tuple[str, int]]
 
@@ -283,6 +284,8 @@ class RegisterClient(_Action):
 
     def _action(self, client):  # type: ignore
         domain = client['domain']
+        if not is_lowercase(domain):
+            return 'domain must be lowercase', 400
         if self._auth.client_id_for(domain) is not None:
             return 'client already exists', 409
 

--- a/opwen_email_server/utils/string.py
+++ b/opwen_email_server/utils/string.py
@@ -1,0 +1,2 @@
+def is_lowercase(string: str) -> bool:
+    return string.lower() == string

--- a/tests/opwen_email_server/test_actions.py
+++ b/tests/opwen_email_server/test_actions.py
@@ -333,6 +333,13 @@ class RegisterClientTests(TestCase):
         self.setup_mx_records = MagicMock()
         self.client_id_source = MagicMock()
 
+    def test_400(self):
+        domain = 'TEST.com'
+
+        _, status = self._execute_action({'domain': domain})
+
+        self.assertEqual(status, 400)
+
     def test_409(self):
         domain = 'test.com'
 

--- a/tests/opwen_email_server/utils/test_string.py
+++ b/tests/opwen_email_server/utils/test_string.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from opwen_email_server.utils.string import is_lowercase
+
+
+class IsLowercaseTests(TestCase):
+    def test_lowercase(self):
+        self.assertTrue(is_lowercase('foo'))
+
+    def test_uppercase(self):
+        self.assertFalse(is_lowercase('FoO'))


### PR DESCRIPTION
We're using Azure storage blob containers under the hood to map clients to their state. Containers are created as lower-case so the client names should also be lower-case.