### PR TITLE
Fix flower deployment on k8s

### DIFF
--- a/helm/templates/api-autoscaler.yaml
+++ b/helm/templates/api-autoscaler.yaml
@@ -2,12 +2,12 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
-  name: api
+  name: {{ .Release.Name }}-api
 spec:
   maxReplicas: 9
   minReplicas: 3
   scaleTargetRef:
     apiVersion: extensions/v1beta1
     kind: Deployment
-    name: api
+    name: {{ .Release.Name }}-api
   targetCPUUtilizationPercentage: 75

--- a/helm/templates/api-deployment.yaml
+++ b/helm/templates/api-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: api
-  name: api
+    io.kompose.service: {{ .Release.Name }}-api
+  name: {{ .Release.Name }}-api
 spec:
   replicas: 1
   strategy: {}
@@ -15,7 +15,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.service: api
+        io.kompose.service: {{ .Release.Name }}-api
     spec:
       containers:
       - name: api

--- a/helm/templates/api-deployment.yaml
+++ b/helm/templates/api-deployment.yaml
@@ -1,9 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-api

--- a/helm/templates/api-service.yaml
+++ b/helm/templates/api-service.yaml
@@ -6,14 +6,14 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: api
-  name: api
+    io.kompose.service: {{ .Release.Name }}-api
+  name: {{ .Release.Name }}-api
 spec:
   ports:
   - name: "8080"
     port: 8080
     targetPort: 8080
   selector:
-    io.kompose.service: api
+    io.kompose.service: {{ .Release.Name }}-api
 status:
   loadBalancer: {}

--- a/helm/templates/api-service.yaml
+++ b/helm/templates/api-service.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-api

--- a/helm/templates/flower-deployment.yaml
+++ b/helm/templates/flower-deployment.yaml
@@ -1,9 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-flower

--- a/helm/templates/flower-deployment.yaml
+++ b/helm/templates/flower-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: flower
-  name: flower
+    io.kompose.service: {{ .Release.Name }}-flower
+  name: {{ .Release.Name }}-flower
 spec:
   replicas: 1
   strategy: {}
@@ -15,7 +15,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.service: flower
+        io.kompose.service: {{ .Release.Name }}-flower
     spec:
       containers:
       - name: flower

--- a/helm/templates/flower-service.yaml
+++ b/helm/templates/flower-service.yaml
@@ -6,14 +6,14 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: flower
-  name: flower
+    io.kompose.service: {{ .Release.Name }}-flower
+  name: {{ .Release.Name }}-flower
 spec:
   ports:
   - name: "8080"
     port: 8080
     targetPort: 8080
   selector:
-    io.kompose.service: flower
+    io.kompose.service: {{ .Release.Name }}-flower
 status:
   loadBalancer: {}

--- a/helm/templates/flower-service.yaml
+++ b/helm/templates/flower-service.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-flower

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ingress
+  name: {{ .Release.Name }}-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"

--- a/helm/templates/nginx-autoscaler.yaml
+++ b/helm/templates/nginx-autoscaler.yaml
@@ -2,12 +2,12 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
-  name: nginx
+  name: {{ .Release.Name }}-nginx
 spec:
   maxReplicas: 5
   minReplicas: 3
   scaleTargetRef:
     apiVersion: extensions/v1beta1
     kind: Deployment
-    name: nginx
+    name: {{ .Release.Name }}-nginx
   targetCPUUtilizationPercentage: 75

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -1,9 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-nginx

--- a/helm/templates/nginx-deployment.yaml
+++ b/helm/templates/nginx-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: nginx
-  name: nginx
+    io.kompose.service: {{ .Release.Name }}-nginx
+  name: {{ .Release.Name }}-nginx
 spec:
   replicas: 1
   strategy: {}
@@ -15,7 +15,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.service: nginx
+        io.kompose.service: {{ .Release.Name }}-nginx
     spec:
       containers:
       - name: nginx
@@ -24,17 +24,17 @@ spec:
         - name: DNS_RESOLVER
           value: 127.0.0.1:53 ipv6=off
         - name: HOSTNAME_FLOWER
-          value: flower:8080
+          value: "{{ .Release.Name }}-flower:8080"
         - name: HOSTNAME_CLIENT_METRICS
-          value: api:8080
+          value: "{{ .Release.Name }}-api:8080"
         - name: HOSTNAME_CLIENT_READ
-          value: api:8080
+          value: "{{ .Release.Name }}-api:8080"
         - name: HOSTNAME_CLIENT_WRITE
-          value: api:8080
+          value: "{{ .Release.Name }}-api:8080"
         - name: HOSTNAME_EMAIL_RECEIVE
-          value: api:8080
+          value: "{{ .Release.Name }}-api:8080"
         - name: HOSTNAME_CLIENT_REGISTER
-          value: api:8080
+          value: "{{ .Release.Name }}-api:8080"
         ports:
         - containerPort: 8888
         resources: {}

--- a/helm/templates/nginx-service.yaml
+++ b/helm/templates/nginx-service.yaml
@@ -6,14 +6,14 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: nginx
-  name: nginx
+    io.kompose.service: {{ .Release.Name }}-nginx
+  name: {{ .Release.Name }}-nginx
 spec:
   ports:
   - name: "8888"
     port: 8888
     targetPort: 8888
   selector:
-    io.kompose.service: nginx
+    io.kompose.service: {{ .Release.Name }}-nginx
 status:
   loadBalancer: {}

--- a/helm/templates/nginx-service.yaml
+++ b/helm/templates/nginx-service.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-nginx

--- a/helm/templates/worker-autoscaler.yaml
+++ b/helm/templates/worker-autoscaler.yaml
@@ -2,12 +2,12 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   creationTimestamp: null
-  name: worker
+  name: {{ .Release.Name }}-worker
 spec:
   maxReplicas: 9
   minReplicas: 3
   scaleTargetRef:
     apiVersion: extensions/v1beta1
     kind: Deployment
-    name: worker
+    name: {{ .Release.Name }}-worker
   targetCPUUtilizationPercentage: 75

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -1,9 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file=compose.yml --chart
-    kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
     io.kompose.service: {{ .Release.Name }}-worker

--- a/helm/templates/worker-deployment.yaml
+++ b/helm/templates/worker-deployment.yaml
@@ -6,8 +6,8 @@ metadata:
     kompose.version: 1.13.0 (84fa826)
   creationTimestamp: null
   labels:
-    io.kompose.service: worker
-  name: worker
+    io.kompose.service: {{ .Release.Name }}-worker
+  name: {{ .Release.Name }}-worker
 spec:
   replicas: 1
   strategy: {}
@@ -15,7 +15,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        io.kompose.service: worker
+        io.kompose.service: {{ .Release.Name }}-worker
     spec:
       containers:
       - name: worker


### PR DESCRIPTION
The flower pod is currently crashing with the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/flower", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/flower/__main__.py", line 11, in main
    flower.execute_from_commandline()
  File "/usr/local/lib/python3.6/site-packages/celery/bin/base.py", line 298, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/usr/local/lib/python3.6/site-packages/flower/command.py", line 56, in handle_argv
    return self.run_from_argv(prog_name, argv)
  File "/usr/local/lib/python3.6/site-packages/flower/command.py", line 33, in run_from_argv
    self.apply_env_options()
  File "/usr/local/lib/python3.6/site-packages/flower/command.py", line 71, in apply_env_options
    value = option.type(value)
ValueError: invalid literal for int() with base 10: 'tcp://10.0.75.166:8080'
```

This is because k8s auto-injects a variable of the form `{deployment_name}_PORT` which mistakenly gets read by flower: `FLOWER_PORT=tcp://10.0.75.166:8080`. Namespacing all the k8s objects with the release name should fix this issue.