### PR TITLE
Ensure kubeval runs on helm template output

### DIFF
--- a/makefile
+++ b/makefile
@@ -49,7 +49,7 @@ lint-shell:
 
 lint-helm:
 	helm lint --strict ./helm/opwen_cloudserver
-	mkdir -p ./k8s-temp && helm template ./helm/opwen_cloudserver --output-dir ./k8s-temp && kubeval -d k8s-temp --ignore-missing-schemas && rm -rf k8s-temp
+	helm template ./helm/opwen_cloudserver > helm.yaml && kubeval --ignore-missing-schemas helm.yaml && rm helm.yaml
 
 lint: lint-python lint-shell lint-swagger lint-docker lint-yaml lint-helm
 


### PR DESCRIPTION
I noticed in one of the CI logs a warning from kubeval mentioning an empty document:

![Screenshot showing kubeval warning](https://user-images.githubusercontent.com/1086421/73716210-5a518080-46e4-11ea-9959-d829f6d585f4.png)

It appears that kubeval in the current setup expects a single k8s yaml file so we can instruct helm to generate that instead of a directory which then logs the linting results as expected:

![Screenshot showing kubeval linting results](https://user-images.githubusercontent.com/1086421/73716445-04310d00-46e5-11ea-8565-ef9c368350b8.png)

See https://github.com/ascoderu/opwen-cloudserver/issues/246